### PR TITLE
Limit hyperlink search region to 1K of text

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/HyperlinkManager.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/hyperlink/HyperlinkManager.java
@@ -267,6 +267,10 @@ public class HyperlinkManager implements ITextListener, Listener, KeyListener, M
 	 * @since 3.7
 	 */
 	private IHyperlink[] findHyperlinks(IRegion region) {
+
+		if (region.getLength() > 1024)
+			return null;
+
 		List<IHyperlink> allHyperlinks= new ArrayList<>(fHyperlinkDetectors.length * 2);
 		synchronized (fHyperlinkDetectors) {
 			for (IHyperlinkDetector detector : fHyperlinkDetectors) {


### PR DESCRIPTION
Overwise there is a side effect if CRTL-S,
CTRL-V, CTRL-C etc. pressed and mouse hold or
move over big line of text.

Bug #218735