### PR TITLE
Inline code minings can optionally be bound to next char

### DIFF
--- a/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningLineContentAnnotation.java
@@ -65,10 +65,11 @@ public class CodeMiningLineContentAnnotation extends LineContentAnnotation imple
 	 * Code mining annotation constructor.
 	 *
 	 * @param position the position
-	 * @param viewer   the viewer
+	 * @param preferDrawingLeftToNextChar stick the annotation to the next char
+	 * @param viewer the viewer
 	 */
-	public CodeMiningLineContentAnnotation(Position position, ISourceViewer viewer) {
-		super(position, viewer);
+	public CodeMiningLineContentAnnotation(Position position, boolean preferDrawingLeftToNextChar, ISourceViewer viewer) {
+		super(position, preferDrawingLeftToNextChar, viewer);
 		fResolvedMinings= null;
 		fMinings= new ArrayList<>();
 		fBounds= new ArrayList<>();

--- a/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/internal/text/codemining/CodeMiningManager.java
@@ -251,11 +251,12 @@ public class CodeMiningManager implements Runnable {
 			Position pos= new Position(g.getKey().offset, g.getKey().length);
 			List<ICodeMining> minings= g.getValue();
 			boolean inLineHeader= !minings.isEmpty() ? (minings.get(0) instanceof LineHeaderCodeMining) : true;
+			boolean preferDrawingLeftToNextChar= !minings.isEmpty() ? (minings.get(0).getPreferDrawingLeftToNextChar()) : false;
 			// Try to find existing annotation
 			AbstractInlinedAnnotation ann= fInlinedAnnotationSupport.findExistingAnnotation(pos);
 			if (ann == null) {
 				// The annotation doesn't exists, create it.
-				ann= inLineHeader ? new CodeMiningLineHeaderAnnotation(pos, viewer) : new CodeMiningLineContentAnnotation(pos, viewer);
+				ann= inLineHeader ? new CodeMiningLineHeaderAnnotation(pos, viewer) : new CodeMiningLineContentAnnotation(pos, preferDrawingLeftToNextChar, viewer);
 			} else if (ann instanceof ICodeMiningAnnotation && ((ICodeMiningAnnotation) ann).isInVisibleLines()) {
 				// annotation is in visible lines
 				annotationsToRedraw.add((ICodeMiningAnnotation) ann);

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/AbstractCodeMining.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/AbstractCodeMining.java
@@ -40,6 +40,11 @@ public abstract class AbstractCodeMining implements ICodeMining {
 	private final Position position;
 
 	/**
+	 * Stick the annotation to the next char
+	 */
+	private boolean preferDrawingLeftToNextChar;
+
+	/**
 	 * The owner codemining provider which creates this mining.
 	 */
 	private final ICodeMiningProvider provider;
@@ -75,6 +80,21 @@ public abstract class AbstractCodeMining implements ICodeMining {
 	@Override
 	public Position getPosition() {
 		return position;
+	}
+
+	@Override
+	public boolean getPreferDrawingLeftToNextChar() {
+		return preferDrawingLeftToNextChar;
+	}
+
+	/**
+	 * Stick the annotation to the next char. This overrides the default behavior of sticking to the
+	 * previous char
+	 *
+	 * @param preferDrawingLeftToNextChar true if the code mining should stick to the next char.
+	 */
+	public void setPreferDrawingLeftToNextChar(boolean preferDrawingLeftToNextChar) {
+		this.preferDrawingLeftToNextChar= preferDrawingLeftToNextChar;
 	}
 
 	@Override

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/codemining/ICodeMining.java
@@ -46,6 +46,14 @@ public interface ICodeMining {
 	Position getPosition();
 
 	/**
+	 * Stick the annotation to the next char. This overrides the default behavior of sticking to the
+	 * previous char
+	 *
+	 * @param preferDrawingLeftToNextChar true if the code mining should stick to the next char.
+	 */
+	boolean getPreferDrawingLeftToNextChar();
+
+	/**
 	 * Returns the owner provider which has created this mining.
 	 *
 	 * @return the owner provider which has created this mining.

--- a/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
+++ b/org.eclipse.jface.text/src/org/eclipse/jface/text/source/inlined/LineContentAnnotation.java
@@ -39,14 +39,18 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 
 	private int redrawnCharacterWidth;
 
+	private boolean preferDrawingLeftToNextChar;
+
 	/**
 	 * Line content annotation constructor.
 	 *
 	 * @param position the position where the annotation must be drawn.
-	 * @param viewer   the {@link ISourceViewer} where the annotation must be drawn.
+	 * @param preferDrawingLeftToNextChar stick the annotation to the next char
+	 * @param viewer the {@link ISourceViewer} where the annotation must be drawn.
 	 */
-	public LineContentAnnotation(Position position, ISourceViewer viewer) {
+	public LineContentAnnotation(Position position, boolean preferDrawingLeftToNextChar, ISourceViewer viewer) {
 		super(position, viewer);
+		this.preferDrawingLeftToNextChar= preferDrawingLeftToNextChar;
 	}
 
 	/**
@@ -154,8 +158,13 @@ public class LineContentAnnotation extends AbstractInlinedAnnotation {
 	}
 
 	boolean drawRightToPreviousChar(int widgetOffset) {
-		return widgetOffset > 0 &&
-				getTextWidget().getLineAtOffset(widgetOffset) == getTextWidget().getLineAtOffset(widgetOffset - 1);
+		StyledText widget= getTextWidget();
+		int widgetLine= widget.getLineAtOffset(widgetOffset);
+		boolean shouldDrawLeftToNextChar= preferDrawingLeftToNextChar
+				&& widgetOffset < getTextWidget().getOffsetAtLine(widgetLine) + getTextWidget().getLine(widgetLine).length();
+		return widgetOffset > 0
+				&& widgetLine == getTextWidget().getLineAtOffset(widgetOffset - 1)
+				&& !shouldDrawLeftToNextChar;
 	}
 
 }


### PR DESCRIPTION
As it is, an annotation is bound with its previous char, unless it's the end of the line. There are cases when it's preferable to have it combined with the next char instead. 

Examples:
1) Source text: 
20 2 
Annotated text:
20x+ 2

1) Source text: 
array 2
Annotated text:
array [2]

The PR provides a way to change the default behavior optionally.